### PR TITLE
fixed not showing login error

### DIFF
--- a/timeandplace/main/views.py
+++ b/timeandplace/main/views.py
@@ -28,23 +28,24 @@ def register_request(request):
 
 def login_request(request):
 	if request.method == "POST":
-		form = AuthenticationForm(request, data=request.POST)
-		if form.is_valid():
-			username = form.cleaned_data.get('username')
-			password = form.cleaned_data.get('password')
-			user = authenticate(username=username, password=password)
-			if user is not None:
+		try:
+			form = AuthenticationForm(request, data=request.POST)
+			# Valid the user form
+			if form.is_valid():
+				username = form.cleaned_data.get('username')
+				password = form.cleaned_data.get('password')
+				user = authenticate(username=username, password=password)
 				login(request, user)
 				messages.info(request, f"You are now logged in as {username}.")
-				return redirect("main:index")
-			else:
-				messages.error(request,"Invalid username or password.")
-		else:
-			messages.error(request,"Invalid username or password.")
-	form = AuthenticationForm()
+		except:
+			messages.error(request,"Login error. Invalid username or password.")
+			return redirect("main:index")
+	else:
+		form = AuthenticationForm()
+
 	return render(request=request, template_name="main/login.html", context={"login_form":form})
 
 def logout_request(request):
 	logout(request)
-	messages.info(request, "You have successfully logged out.") 
+	messages.info(request, "You have successfully logged out.")
 	return redirect("main:index")

--- a/timeandplace/timeandplace/settings.py
+++ b/timeandplace/timeandplace/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = '6afn+0ee8viojn(-m^jknuzovg^ino=#zleg4au)2mi=ir7aaq'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['timeandplace-dev.eba-ngz3apug.us-west-2.elasticbeanstalk.com','timeandplace-dev.eba-juwihe4w.us-west-2.elasticbeanstalk.com']
+ALLOWED_HOSTS = ['127.0.0.1', 'timeandplace-dev.eba-ngz3apug.us-west-2.elasticbeanstalk.com','timeandplace-dev.eba-juwihe4w.us-west-2.elasticbeanstalk.com']
 
 
 # Application definition


### PR DESCRIPTION
Previously when the user tried to log in and failed, it automatically redirects to the main page showing no error.
Fixed to make the login page actually show the error instead of redirection. 